### PR TITLE
bug fix to display clicked-on image

### DIFF
--- a/backend/mainapp/templates/gallery.html
+++ b/backend/mainapp/templates/gallery.html
@@ -117,6 +117,7 @@
         images = Array.from(document.querySelectorAll(".card-img-top")).map(img => img.src);
     });
 
+
     function openModal(imageSrc) {
         currentIndex = images.indexOf(imageSrc); // Set correct index
         if (currentIndex === -1) {


### PR DESCRIPTION
another attempt at bug fix to display clicked-on image instead of first in list ("oldest"): normalized URLs (absolute URLs)